### PR TITLE
Set `position:fixed` like the other modals

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -647,7 +647,7 @@ input:-webkit-autofill {
     left: 50%;
     margin-left: -150px;
     opacity: 0;
-    position: absolute;
+    position: fixed;
     transition: all .3s ease;
     width: 300px;
     z-index: 2;


### PR DESCRIPTION
Unlike the other modals the #upload-info box is positioned absolutely, which allows the user to scroll down the `html` element.
![image](https://f.cloud.github.com/assets/2925395/2191794/bc22a820-9853-11e3-83f4-f5af5dd6fd05.png)
html overflow:hidden was disabled so you can see the scroll bar, and the half scrolled page.
