### PR TITLE
TLS: Fix missing optional intermediate cert error

### DIFF
--- a/droppy.js
+++ b/droppy.js
@@ -415,7 +415,7 @@ function createListener(handler) {
         try {
             key = fs.readFileSync(config.tlsKey);
             cert = fs.readFileSync(config.tlsCert);
-            if (config.tls.ca.length) ca = fs.readFileSync(config.tlsCA);
+            if (fs.existsSync(config.tlsCA)) ca = fs.readFileSync(config.tlsCA);
         } catch (error) {
             log.error("Couldn't read required TLS keys or certificates.", util.inspect(error));
             process.exit(1);


### PR DESCRIPTION
There was a typo in line 418, which should have read `config.tlsCA.length`, but that caused another error because apparently `"tlsCA": "./ca.pem"` kept getting appended to config.json every time I tried to delete that line, and setting the value to `null`, `undefined`, or an empty string didn't work either. This does a proper check for whether or not the optional intermediate certificate exists at the specified path, and TLS now works for me without an intermediate certificate.
