### PR TITLE
add environment variables to initialise droppy in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ $ docker run --name droppy -p 127.0.0.1:8989:8989 silverwind/droppy
 
 This method uses automatic volumes for `/config` and `/files` which can be overridden through `-v /srv/droppy/config:/config` and `-v /srv/droppy/files:/files`. If you're using existing files, it's advisable to use `-e UID=1000 -e GID=1000` to get new files written with correct ownership.
 
+You can also set the default privileged username and password using `-e DROPPY_ADMIN_USER=admin -e DROPPY_ADMIN_PASSWORD=[your admin password]`.
+
 To update a docker installation, run
 
 ```sh

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -13,12 +13,12 @@ echo -e "droppy:x:${GID}:droppy\n" >> /etc/group
 mkdir -p /config
 mkdir -p /files
 
-chown -R droppy:droppy /config
-chown droppy:droppy /files
-
-
 if [[ -n "$DROPPY_ADMIN_USER" && -n "$DROPPY_ADMIN_PASSWORD" ]]; then
     droppy add "$DROPPY_ADMIN_USER" "$DROPPY_ADMIN_PASSWORD" true
 fi
+
+chown -R droppy:droppy /config
+chown droppy:droppy /files
+
 
 exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config" droppy

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -16,4 +16,9 @@ mkdir -p /files
 chown -R droppy:droppy /config
 chown droppy:droppy /files
 
+
+if [[ -n "$DROPPY_ADMIN_USER" && -n "$DROPPY_ADMIN_PASSWORD" ]]; then
+    droppy add "$DROPPY_ADMIN_USER" "$DROPPY_ADMIN_PASSWORD" true
+fi
+
 exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config" droppy


### PR DESCRIPTION
added `DROPPY_ADMIN_USER` and `DROPPY_ADMIN_PASSWORD` environment variables to `docker-start.sh`

Doesn't impact users who don't set these environment variables, or users who aren't using docker.

I built and tested this on an amd64 machine, and although I haven't tested on armhf or arm64 I dont think it will present any problems.