### PR TITLE
pass-through cli arguments to droppy start

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -16,4 +16,4 @@ mkdir -p /files
 chown -R droppy:droppy /config
 chown droppy:droppy /files
 
-exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config" droppy
+exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config $@" droppy


### PR DESCRIPTION
Allow docker run to pass arbitrary command line arguments into droppy start