### PR TITLE
Fix follow symlinks

### DIFF
--- a/server/filetree.js
+++ b/server/filetree.js
@@ -103,13 +103,13 @@ filetree.updateDir = async function(dir) {
   if (initial) { // sync walk for performance
     initial = false;
     try {
-      entries = rrdir.sync(fullDir, {stats: true, exclude: cfg.ignorePatterns});
+      entries = rrdir.sync(fullDir, {stats: true, exclude: cfg.ignorePatterns, followSymlinks: true});
     } catch (err) {
       log.error(err);
     }
   } else {
     try {
-      entries = await rrdir.async(fullDir, {stats: true, exclude: cfg.ignorePatterns});
+      entries = await rrdir.async(fullDir, {stats: true, exclude: cfg.ignorePatterns, followSymlinks: true});
     } catch (err) {
       log.error(err);
     }


### PR DESCRIPTION
Fixes #437

It looks like [rrdir](https://github.com/silverwind/rrdir) used to follow symlinks by default and [now doesn't](https://github.com/silverwind/rrdir/releases/tag/7.0.0) so [updating it](https://github.com/silverwind/droppy/commit/68664d5a1daf5f3a5b207bc97b663ad6fca8538f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R45) in 12.0.0 broke that. This PR adds the `followSymlinks` option to make it follow symlinks again.

I don't know if it should also be added there: https://github.com/silverwind/droppy/blob/master/server/server.js#L1399.